### PR TITLE
Add tox action

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,28 @@
+name: tox ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install distro build deps
+      run: sudo apt-get install -y libvirt-dev python3-dev gcc libffi-dev
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist =
+    clean
+    build
     tests
     lint
     docs
@@ -77,6 +79,11 @@ deps =
     autopep8
 commands =
     autopep8 --max-line-length=79 --in-place -r {posargs:src arbiterd_tests}
+
+[gh-actions]
+python =
+    3.8: clean, build, tests, lint, docs
+    3.9: tests
 
 [flake8]
 max_line_length = 79


### PR DESCRIPTION
This change adds basic ci coverage using tox
to validate changes on push and pull request
using python 3.8 and 3.9
