### PR TITLE
run pytest and tox in parallel in ci

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -25,4 +25,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox
+      run: tox -p

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ testing =
     pytest-cov
     fixtures
     testtools
+    pytest-xdist
 
 [options.entry_points]
 console_scripts =

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ setenv =
 extras =
     testing
 commands =
-    pytest {posargs}
+    pytest -n auto {posargs}
 
 [testenv:{build,clean}]
 description =


### PR DESCRIPTION
This change add pytest-xdist to allow parallel
execution of pytest tests

This change alters the tox workflow to run with tox -p
