### PR TITLE
Add basic command to set and show cpu state.

### DIFF
--- a/arbiterd_tests/unit/common/cpu_test.py
+++ b/arbiterd_tests/unit/common/cpu_test.py
@@ -72,7 +72,9 @@ class TestCPU(testtools.TestCase):
 
     def test_get_cpu_path(self):
         with mock.patch(
-                'arbiterd.common.filesystem.get_sys_fs_mount') as sys_mock:
+                'arbiterd.common.filesystem.get_sys_fs_mount') as sys_mock,\
+            mock.patch(
+                'arbiterd.common.cpu.exists', return_value=True):
             sys_mock.return_value = '/sys'
             self.assertEqual(
                 cpu.gen_cpu_path(1), '/sys/devices/system/cpu/cpu1')

--- a/arbiterd_tests/unit/common/libvirt_test.py
+++ b/arbiterd_tests/unit/common/libvirt_test.py
@@ -34,7 +34,7 @@ class TestLibvirt(testtools.TestCase):
         mock_init.return_value = None
         libvirt_obj = libvirt.Libvirt()
         libvirt_obj.get_connection()
-        mock_libvirt.open.assert_called_once()
+        mock_libvirt.openReadOnly.assert_called_once()
 
     @mock.patch.object(libvirt.Libvirt, 'import_libvirt')
     @mock.patch.object(libvirt.Libvirt, 'get_connection')

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     libvirt-python
+    defusedxml
 
 [options.packages.find]
 where = src

--- a/src/arbiterd/common/filesystem.py
+++ b/src/arbiterd/common/filesystem.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+import logging
 import os
 import typing as ty
 
@@ -10,6 +11,8 @@ SYS = '/sys'
 SYSFS = 'sysfs'
 MTAB = '/etc/mtab'
 ETC = '/etc'
+
+LOG = logging.getLogger(__name__)
 
 
 @functools.lru_cache
@@ -37,23 +40,30 @@ def get_etc_fs_mount() -> str:
     return ETC
 
 
-def read_sys(
-        path: str, sys: str = None, default: str = None
-) -> ty.Optional[str]:
-    sys = sys or get_sys_fs_mount()
+def read_sys(path: str, default: str = None) -> ty.Optional[str]:
+    sys = get_sys_fs_mount()
     try:
         with open(os.path.join(sys, path), mode='r') as data:
             return data.read()
-    except (OSError, ValueError):
-        pass
+    except (OSError, ValueError) as e:
+        LOG.debug(e)
     return default
 
 
-def readlines_sys(path: str, sys: str = None) -> ty.List[str]:
-    sys = sys or get_sys_fs_mount()
+def readlines_sys(path: str) -> ty.List[str]:
+    sys = get_sys_fs_mount()
     try:
         with open(os.path.join(sys, path), mode='r') as data:
             return data.readlines()
-    except (OSError, ValueError):
-        pass
+    except (OSError, ValueError) as e:
+        LOG.debug(e)
     return []
+
+
+def write_sys(path: str, data: str = None) -> ty.Optional[str]:
+    sys = get_sys_fs_mount()
+    try:
+        with open(os.path.join(sys, path), mode='w') as fd:
+            fd.write(data)
+    except (OSError, ValueError) as e:
+        LOG.debug(e)

--- a/src/arbiterd/common/libvirt.py
+++ b/src/arbiterd/common/libvirt.py
@@ -25,9 +25,15 @@ class Libvirt(object):
 
     def get_connection(self) -> ty.Optional:
         try:
-            return libvirt.open('qemu:///system')
+            return libvirt.openReadOnly('qemu:///system')
         except libvirt.libvirtError:
             return None
 
     def list_domains(self) -> ty.Iterable:
         return self.conn.listAllDomains(0)
+
+    def get_domain_by_name(self, name: str) -> 'libvirt.virDomain':
+        return self.conn.lookupByName(name)
+
+    def get_domain_by_uuid(self, uuid: str) -> 'libvirt.virDomain':
+        return self.conn.lookupByUUID(uuid)


### PR DESCRIPTION
This change add the ability to show the current cpu state
and set indivigual cpus online or offline

This change adds the ability to show libvirt domain xmls
by name or uuid.

This change alters the list --domains command to remove the
vcpu info.

This change add defusexml as a currently unused dep which will
be consumed to safely parse domain xmls in the future.
