### PR TITLE
Add inital tooling to automate packaging

### DIFF
--- a/tools/arbiterd-ctl.sh
+++ b/tools/arbiterd-ctl.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+_XTRACE_DEBUG=$(set +o | grep xtrace)
+if [[ "${DEBUG_TRACING:-False}" == "True" ]]; then
+    set -o xtrace
+fi
+
+FULL_PATH=$(realpath "${BASH_SOURCE[0]}")
+TOOLS_DIR=$(dirname ${FULL_PATH})
+CONFIG_DIR=${COFIG_DIR:-"/etc/arbiterd"}
+CONFIG_FILE=${CONFIG_FILE:-"${CONFIG_DIR}/arbiterd.conf"}
+SERVICE_FILE="/etc/systemd/system/arbiterd.service"
+REPO_ROOT="$(realpath ${TOOLS_DIR}/.. )"
+
+. $TOOLS_DIR/functions-common
+
+
+function get_value {
+    crudini --get ${CONFIG_FILE} $@
+}
+
+function set_value {
+    crudini --set ${CONFIG_FILE} $1 $2 "$3"
+}
+
+function del_value {
+    crudini --del ${CONFIG_FILE} $@
+}
+
+function is_set {
+    output=$(crudini --get ${CONFIG_FILE} $* &> /dev/null ) && [ -n "$(crudini --get ${CONFIG_FILE} $*)" ]; echo $?
+}
+
+function show_config {
+    cat  ${CONFIG_FILE}
+}
+
+function get_config {
+    echo  ${CONFIG_FILE}
+}
+
+function del_config {
+    sudo rm -f ${CONFIG_FILE}
+}
+
+function is_redhat_family {
+    [[ -e /etc/redhat-release ]] ; echo $?
+}
+
+function gen_config {
+    del_config
+    sudo mkdir -p -m 777 ${CONFIG_DIR}
+    touch ${CONFIG_FILE}
+    if  [[ $(is_redhat_family) == 0 ]]; then
+        set_value build container_runtime ${container_runtime:-"podman"}
+    else
+        set_value build container_runtime ${container_runtime:-"docker"}
+    fi
+    set_value build container_name ${container_name:-"arbiterd"}
+    set_value build container_tag ${container_tag:-"latest"}
+}
+
+function init {
+    gen_config
+}
+
+function is_git_repo {
+    # this can be more robust but this will work for now
+    [[ -e "${REPO_ROOT}/.git" ]] ; echo $?
+}
+
+function setup_source {
+    if  [[ $(is_git_repo) == 0 ]]; then
+        return
+    fi
+     # TODO: make this work
+    die 'use of this script outside of its git repo is not supported'
+}
+
+function install {
+    setup_source
+    init
+}
+
+function clean {
+    del_config
+    sudo rm -rf ${CONFIG_DIR}
+}
+
+function uninstall {
+    clean
+}
+
+function build_wheel {
+    tox -e clean,build
+}
+
+function build_container {
+    runtime=${container_runtime:-$(get_value build container_runtime)}
+    name=${container_name:-$(get_value build container_name)}
+    tag=${container_tag:-$(get_value build container_tag)}
+    pushd ${REPO_ROOT}
+    build_wheel
+    build_command="${runtime} build -t ${name}:${tag} ."
+    ${build_command}
+    popd
+}
+
+function usage {
+    cat << "EOF"
+arbiterd-ctl.sh: A tool to configure arbiterd.
+
+This tool automates the building, packaging and installation
+of arbiterd.
+commands:
+  - install:
+    - TODO: installs arebiterd as a systemd service.
+    - TODO: installs arbiterd-ctl.sh  binary.
+    - TODO: generates arbiterd configuration file.
+  - uninstall:
+    - TODO: stops arebiterd service.
+    - TODO: uninstalls arebiterd systemd service.
+    - TODO: runs clean
+  - init:
+    - create arbiterd directories
+    - generate arbiterd configuration files.
+  - clean:
+    - removes arbiterd config files and directories
+  - setup_source:
+    - TODO: clone arbiterd if script is not executing form git repo.
+            if the script is curled to bash (curl ... | bash) then clone
+            a full copy of there repo. if the script is already in a
+            git repo do nothing.
+  - build_container:
+    - builds contaniner image using \${CONTAINER_RUNTIME}
+    - supported container runtimes are podman and docker.
+    - The current container build is based on python:3.8-alpine
+    - The contienr is built using the wheel produced by build-wheel
+      which is invoked automatically as part of this command.
+  - build_wheel:
+    - build python wheel for arbiterd using tox
+  - build_rpm:
+    - TODO: build rpm for arbiterd.
+  - usage:
+    - prints this message
+options:
+  - debuging:
+    - To enable debuging export DEBUG_TRACING=True
+  - install:
+    - The varibles described below can be defined to customise
+      installation of arbiterd.
+      <variable>=<value> arbiterd-ctl.sh install
+    - container_runtime: docker|podman
+    - container_name: any docker/podman allowable name default(arbiterd)
+    - container_tag: any docker/podman allowable tag default(latest)
+EOF
+
+}
+
+if [ $# -ge  1 ]; then
+    func=$1
+    shift
+else
+    func="usage"
+fi
+
+#replace with switch later
+eval "$func $@"
+
+
+${_XTRACE_DEBUG}

--- a/tools/functions-common
+++ b/tools/functions-common
@@ -1,0 +1,76 @@
+
+# These fucntions are imported directly from devstacks functions-common
+# https://github.com/openstack/devstack/blob/6c849e371384e468679d3d030fe494a36587c505/functions-common
+
+#Control Functions
+# =================
+
+# Prints backtrace info
+# filename:lineno:function
+# backtrace level
+function backtrace {
+    local level=$1
+    local deep
+    deep=$((${#BASH_SOURCE[@]} - 1))
+    echo "[Call Trace]"
+    while [ $level -le $deep ]; do
+        echo "${BASH_SOURCE[$deep]}:${BASH_LINENO[$deep-1]}:${FUNCNAME[$deep-1]}"
+        deep=$((deep - 1))
+    done
+}
+
+# Prints line number and "message" then exits
+# die $LINENO "message"
+function die {
+    local exitcode=$?
+    set +o xtrace
+    local line=$1; shift
+    if [ $exitcode == 0 ]; then
+        exitcode=1
+    fi
+    backtrace 2
+    err $line "$*"
+    # Give buffers a second to flush
+    sleep 1
+    exit $exitcode
+}
+
+# Test if the named environment variable is set and not zero length
+# is_set env-var
+function is_set {
+    local var=\$"$1"
+    eval "[ -n \"$var\" ]" # For ex.: sh -c "[ -n \"$var\" ]" would be better, but several exercises depends on this
+}
+
+# Checks an environment variable is not set or has length 0 OR if the
+# exit code is non-zero and prints "message" and exits
+# NOTE: env-var is the variable name without a '$'
+# die_if_not_set $LINENO env-var "message"
+function die_if_not_set {
+    local exitcode=$?
+    local xtrace
+    xtrace=$(set +o | grep xtrace)
+    set +o xtrace
+    local line=$1; shift
+    local evar=$1; shift
+    if ! is_set $evar || [ $exitcode != 0 ]; then
+        die $line "$*"
+    fi
+    $xtrace
+}
+
+# Prints line number and "message" in error format
+# err $LINENO "message"
+function err {
+    local exitcode=$?
+    local xtrace
+    xtrace=$(set +o | grep xtrace)
+    set +o xtrace
+    local msg="[ERROR] ${BASH_SOURCE[2]}:$1 $2"
+    echo "$msg" 1>&2;
+    if [[ -n ${LOGDIR} ]]; then
+        echo "$msg" >> "${LOGDIR}/error.log"
+    fi
+    $xtrace
+    return $exitcode
+}

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,10 @@ extras =
 commands =
     pytest -n auto {posargs}
 
-[testenv:{build,clean}]
+[testenv:{build,clean,sdist}]
 description =
     build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
+    sdist: Build an sdist package in isolation
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
 skip_install = true
 deps =
@@ -29,7 +30,8 @@ deps =
 changedir = {toxinidir}
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
-    build: python -m build .
+    build: python -m build -w .
+    sdist: python -m build -s .
 
 [testenv:{docs,doctests,linkcheck}]
 description =


### PR DESCRIPTION
This change introduces tools/arbiter-ctl.sh
to automate building arbiterd as a contaienr.

it will be extneded in the future to manage installation
of arbiterd as a systemd service and its config files.

This change also modifes tox to build only the binary wheel as part
of the build env and adds a sdist env to build the sdist package.
