### PR TITLE
add unit tests for cpu state arbiter

### DIFF
--- a/arbiterd_tests/base.py
+++ b/arbiterd_tests/base.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import fixtures
 import testtools
-
 from arbiterd.common import filesystem
+
 from arbiterd_tests import fixtures as at_fixtures
 
 

--- a/arbiterd_tests/base_test.py
+++ b/arbiterd_tests/base_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import logging
 import unittest
 

--- a/arbiterd_tests/conftest.py
+++ b/arbiterd_tests/conftest.py
@@ -7,5 +7,4 @@
     - https://docs.pytest.org/en/stable/fixture.html
     - https://docs.pytest.org/en/stable/writing_plugins.html
 """
-
 # import pytest

--- a/arbiterd_tests/fixtures.py
+++ b/arbiterd_tests/fixtures.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import os
 import shutil
 import tempfile

--- a/arbiterd_tests/functional/common/cpu_test.py
+++ b/arbiterd_tests/functional/common/cpu_test.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import os
 
+from arbiterd.common import cpu
+from arbiterd.common import filesystem
 from testtools.content import text_content
 
-from arbiterd.common import cpu, filesystem
 from arbiterd_tests import base
 
 

--- a/arbiterd_tests/functional/common/nova_test.py
+++ b/arbiterd_tests/functional/common/nova_test.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import configparser
 import os
 
-from arbiterd.common import filesystem, nova
+from arbiterd.common import filesystem
+from arbiterd.common import nova
+
 from arbiterd_tests import base
 
 

--- a/arbiterd_tests/unit/arbiters/cpu_state_test.py
+++ b/arbiterd_tests/unit/arbiters/cpu_state_test.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
+# SPDX-License-Identifier: Apache-2.0
+import typing as ty
+from unittest import mock
+
+import testtools
+from arbiterd.arbiters import cpu_state
+from arbiterd.objects import context
+from arbiterd.objects import hardware_thread
+from arbiterd.objects import instance
+
+
+class TestCPUStateArbiter(testtools.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.arbiter = cpu_state.CPUStateArbiter()
+        self.uuid = mock.sentinel.instance
+        self.vm = mock.create_autospec(
+            instance.Instance, spec_set=True, instance=True,
+            uuid=self.uuid, name='test-vm',
+        )
+        self.vm_cpus = {0, 1, 2, 3}
+        self.vm.cpu_affinities = instance.CPUAffinity(
+            self.vm_cpus,  self.vm_cpus,  self.vm_cpus, set()
+        )
+
+    def generate_thread_list(
+            self, count: int = 10, online: bool = True
+    ) -> ty.List[hardware_thread.HardwareThread]:
+        threads = []
+        for i in range(count):
+            thread = mock.create_autospec(
+                hardware_thread.HardwareThread, spec_set=True, instance=True,
+                ident=i, online=online
+            )
+            threads.append(thread)
+
+        return threads
+
+    def test_arbitrate_empty_context(self):
+        ctx = context.Context()
+        result = self.arbiter.arbitrate(ctx)
+        # an empty context has dry_run set to true so match
+        # the message printed for the dry_run case.
+        self.assertIn('offlinable_cpus:', result)
+
+    def test_arbitrate_empty_context_dry_run_false(self):
+        ctx = context.Context(dry_run=False)
+        result = self.arbiter.arbitrate(ctx)
+        self.assertIn('offlined cpus:', result)
+
+    def test_arbitrate_no_instances(self):
+        threads = self.generate_thread_list()
+        for t in threads:
+            self.assertTrue(t.online)
+        ctx = context.Context(dry_run=False, managed_hardware_threads=threads)
+        result = self.arbiter.arbitrate(ctx)
+        self.assertIn('offlined cpus:', result)
+        for t in threads:
+            self.assertFalse(t.online)
+
+    def test_arbitrate_with_instance(self):
+        threads = self.generate_thread_list()
+        for t in threads:
+            self.assertTrue(t.online)
+        ctx = context.Context(
+            dry_run=False, instances=[self.vm],
+            managed_hardware_threads=threads
+        )
+        result = self.arbiter.arbitrate(ctx)
+        self.assertIn('offlined cpus:', result)
+        for t in threads:
+            self.assertEqual(
+                t.online, t.ident in self.vm_cpus,
+                f'core {t.ident} expected state: {t.ident in self.vm_cpus}'
+                f' actual {t.online}'
+            )
+
+    def test_get_online_cores(self):
+        threads = self.generate_thread_list()
+        result = self.arbiter.get_online_cores(threads)
+        self.assertEqual({t.ident for t in threads}, result)
+
+    def test_get_offline_cores(self):
+        threads = self.generate_thread_list()
+        result = self.arbiter.get_offline_cores(threads)
+        self.assertEqual(set(), result)
+
+    def test_register(self):
+        data = {}
+        cpu_state.register(data)
+        self.assertEqual(len(data), 1)
+        self.assertIn(cpu_state.CPUStateArbiter.TYPE, data)
+        self.assertIs(
+            data[cpu_state.CPUStateArbiter.TYPE], cpu_state.CPUStateArbiter)
+
+    def test_revoke_empty_context(self):
+        ctx = context.Context()
+        result = self.arbiter.revoke(ctx)
+        # an empty context has dry_run set to true so match
+        # the message printed for the dry_run case.
+        self.assertIn('onlinable_cpus:', result)
+
+    def test_revoke_empty_context_dry_run_false(self):
+        ctx = context.Context(dry_run=False)
+        result = self.arbiter.revoke(ctx)
+        self.assertIn('onlined cpus:', result)
+
+    def test_revoke_no_instances(self):
+        threads = self.generate_thread_list(online=False)
+        for t in threads:
+            self.assertFalse(t.online)
+        ctx = context.Context(dry_run=False, managed_hardware_threads=threads)
+        result = self.arbiter.revoke(ctx)
+        self.assertIn('onlined cpus:', result)
+        for t in threads:
+            self.assertTrue(t.online)
+
+    def test_revoke_with_instance(self):
+        threads = self.generate_thread_list()
+        for t in threads:
+            self.assertTrue(t.online)
+        ctx = context.Context(
+            dry_run=False, instances=[self.vm],
+            managed_hardware_threads=threads
+        )
+        result = self.arbiter.arbitrate(ctx)
+        self.assertIn('offlined cpus:', result)
+        for t in threads:
+            self.assertEqual(
+                t.online, t.ident in self.vm_cpus,
+                f'core {t.ident} expected state: {t.ident in self.vm_cpus}'
+                f' actual {t.online}'
+            )
+        result = self.arbiter.revoke(ctx)
+        self.assertIn('onlined cpus:', result)
+        for t in threads:
+            self.assertTrue(t.online)

--- a/arbiterd_tests/unit/common/cpu_test.py
+++ b/arbiterd_tests/unit/common/cpu_test.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import typing as ty
 from unittest import mock
 
 import testtools
-
 from arbiterd.common import cpu
 
 

--- a/arbiterd_tests/unit/common/filesystem_test.py
+++ b/arbiterd_tests/unit/common/filesystem_test.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import os
 from unittest import mock
 
 import testtools
-
 from arbiterd.common import filesystem
+
 from arbiterd_tests import fixtures as at_fixtures
 
 

--- a/arbiterd_tests/unit/common/libvirt_test.py
+++ b/arbiterd_tests/unit/common/libvirt_test.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 from unittest import mock
 
 import testtools
-
 from arbiterd.common import libvirt
 
 

--- a/src/arbiterd/__init__.py
+++ b/src/arbiterd/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/arbiterd/arbiters/__init__.py
+++ b/src/arbiterd/arbiters/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import importlib
 import logging
 import pkgutil

--- a/src/arbiterd/cmd/static.py
+++ b/src/arbiterd/cmd/static.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import argparse
 import logging
 import os
 from pprint import PrettyPrinter
 
 from arbiterd import dispatcher
-from arbiterd.common import cpu, libvirt, nova
-from arbiterd.objects import context, hardware_thread, instance
+from arbiterd.common import cpu
+from arbiterd.common import libvirt
+from arbiterd.common import nova
+from arbiterd.objects import context
+from arbiterd.objects import hardware_thread
+from arbiterd.objects import instance
 
 LOG = logging.getLogger(__name__)
 PRINTER = PrettyPrinter()

--- a/src/arbiterd/common/cpu.py
+++ b/src/arbiterd/common/cpu.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
-
 import logging
 import os
 import typing as ty

--- a/src/arbiterd/common/filesystem.py
+++ b/src/arbiterd/common/filesystem.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import functools
 import logging
 import os

--- a/src/arbiterd/common/libvirt.py
+++ b/src/arbiterd/common/libvirt.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import importlib
 import typing as ty
 

--- a/src/arbiterd/common/nova.py
+++ b/src/arbiterd/common/nova.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import configparser
 import functools
 import typing as ty

--- a/src/arbiterd/dispatcher.py
+++ b/src/arbiterd/dispatcher.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
-
 import dataclasses
 import logging
 import typing as ty

--- a/src/arbiterd/objects/context.py
+++ b/src/arbiterd/objects/context.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import dataclasses
 import typing as ty
 from dataclasses import dataclass

--- a/src/arbiterd/objects/hardware_thread.py
+++ b/src/arbiterd/objects/hardware_thread.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
-
 # import typing as ty
 from dataclasses import dataclass
 

--- a/src/arbiterd/objects/instance.py
+++ b/src/arbiterd/objects/instance.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-
 import collections
 import typing as ty
 from dataclasses import dataclass
 
+from arbiterd.common import cpu
+from arbiterd.common import libvirt
 from defusedxml import ElementTree as ET
-
-from arbiterd.common import cpu, libvirt
 
 # TODO: extract this so it can be shared
 CPUAffinity = collections.namedtuple(


### PR DESCRIPTION
this change adds test coverage and refactors the
arbiter to avoid recreating the thread objects.
