### PR TITLE
add unit tests for objects and dispatcher

### DIFF
--- a/arbiterd_tests/unit/dispatcher_test.py
+++ b/arbiterd_tests/unit/dispatcher_test.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
+# SPDX-License-Identifier: Apache-2.0
+from unittest import mock
+
+import testtools
+from arbiterd import dispatcher
+from arbiterd.arbiters import cpu_state
+
+
+class TestDispatcher(testtools.TestCase):
+
+    def test_init(self):
+        dispatch = dispatcher.Dispatcher()
+        self.assertIsNotNone(dispatch.arbiters)
+        self.assertIn(cpu_state.CPUStateArbiter.TYPE, dispatch.arbiters)
+        self.assertIsInstance(
+            dispatch.arbiters[cpu_state.CPUStateArbiter.TYPE],
+            cpu_state.CPUStateArbiter
+        )
+
+    def test_arbitrate_and_revoke_base(self):
+        dispatch = dispatcher.Dispatcher()
+        arbiter_mock = mock.MagicMock()
+        dispatch.arbiters['fake'] = arbiter_mock
+        dispatch.arbitrate('fake', None)
+        dispatch.revoke('fake', 42)
+        arbiter_mock.arbitrate.assert_called_with(None)
+        arbiter_mock.revoke.assert_called_with(42)

--- a/arbiterd_tests/unit/objects/instance_test.py
+++ b/arbiterd_tests/unit/objects/instance_test.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
+# SPDX-License-Identifier: Apache-2.0
+import os
+from unittest import mock
+
+import testtools
+from arbiterd.objects import instance
+
+import arbiterd_tests.test_data as td
+
+DATA_PATH_BASE = os.path.abspath(td.__path__[0])
+
+
+class TestInstance(testtools.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.dom = mock.MagicMock()
+        self.uuid = mock.sentinel.instance
+        self.dom.UUID.return_value = self.uuid
+        self.dom.UUIDString.return_value = str(self.uuid)
+        self.dom.name.return_value = 'test-domain'
+        test_xml = os.path.join(DATA_PATH_BASE, 'libvirt-domain.xml')
+        with open(test_xml) as f:
+            self.dom.XMLDesc.return_value = f.read()
+
+    def test_default_init(self):
+        inst = instance.Instance()
+        self.assertIsNone(inst.name)
+        self.assertIsNone(inst.uuid)
+        with testtools.ExpectedException(
+                ValueError,
+                'domain lookup failed, name or uuid must be set.*'):
+            inst.domain
+        with testtools.ExpectedException(ValueError):
+            inst.xml
+        with testtools.ExpectedException(ValueError):
+            inst.xml_str
+
+    def test_from_domain(self):
+        inst = instance.Instance.from_domain(self.dom)
+        self.assertEqual(inst.uuid, str(self.uuid))
+        self.assertEqual(inst.name, 'test-domain')
+        self.assertEqual(inst.xml_str, self.dom.XMLDesc.return_value)
+        self.assertTrue(inst.is_nova_instance)
+
+    def test_cpu_affinity(self):
+        inst = instance.Instance.from_domain(self.dom)
+        affinity = inst.cpu_affinities
+        expected = instance.CPUAffinity(
+            set(), {1, 4, 37, 5, 6, 13, 25}, set(), set()
+        )
+        self.assertEqual(affinity, expected)

--- a/arbiterd_tests/unit/objects/test_hardware_thread.py
+++ b/arbiterd_tests/unit/objects/test_hardware_thread.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
+# SPDX-License-Identifier: Apache-2.0
+from unittest import mock
+
+import testtools
+from arbiterd.objects import hardware_thread as ht
+
+
+class TestHardwareThread(testtools.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def test_default_init(self):
+        thread = ht.HardwareThread()
+        self.assertIsNone(thread.ident)
+        self.assertIsNone(thread._path)
+
+    @mock.patch('arbiterd.common.cpu.gen_cpu_path')
+    def test_path(self, gen_mock):
+        thread = ht.HardwareThread(ident=42)
+        gen_mock.return_value = 'test/path'
+        result = thread.path
+        self.assertEqual(result, 'test/path')
+        self.assertEqual(thread._path, 'test/path')
+        gen_mock.assert_called_once_with(42)
+
+    @mock.patch('arbiterd.common.cpu.get_online')
+    def test_online(self, online_mock):
+        thread = ht.HardwareThread(ident=42)
+        thread._path = 'fake/path'
+        online_mock.return_value = True
+        result = thread.online
+        self.assertTrue(result)
+        online_mock.assert_called_once_with('fake/path')
+
+    @mock.patch('arbiterd.common.cpu.set_online')
+    def test_set_online(self, online_mock):
+        thread = ht.HardwareThread(ident=42)
+        thread._path = 'fake/path'
+        online_mock.return_value = True
+        thread.online = True
+        online_mock.assert_called_once_with('fake/path')
+
+    @mock.patch('arbiterd.common.cpu.set_offline')
+    def test_set_offline(self, online_mock):
+        thread = ht.HardwareThread(ident=42)
+        thread._path = 'fake/path'
+        online_mock.return_value = True
+        thread.online = False
+        online_mock.assert_called_once_with('fake/path')

--- a/src/arbiterd/arbiters/base.py
+++ b/src/arbiterd/arbiters/base.py
@@ -19,3 +19,7 @@ class ArbiterBase(abc.ABC):
     @abc.abstractmethod
     def revoke(self, context: ctx.Context) -> str:
         raise NotImplementedError
+
+
+def register(current_arbiters: dict) -> None:
+    pass

--- a/src/arbiterd/arbiters/cpu_state.py
+++ b/src/arbiterd/arbiters/cpu_state.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import typing as ty
+from dataclasses import dataclass
 
 from arbiterd.arbiters import base
 from arbiterd.objects import context as ctx
@@ -12,6 +13,7 @@ from arbiterd.objects import hardware_thread
 LOG = logging.getLogger(__name__)
 
 
+@dataclass
 class CPUStateArbiter(base.ArbiterBase):
     TYPE: str = 'cpu-state'
 

--- a/src/arbiterd/objects/hardware_thread.py
+++ b/src/arbiterd/objects/hardware_thread.py
@@ -29,10 +29,10 @@ class HardwareThread:
 
     @property
     def online(self) -> bool:
-        return self.get_online(self.path)
+        return cpu.get_online(self.path)
 
     @online.setter
-    def online(self, state: bool) -> bool:
+    def online(self, state: bool) -> None:
         if state:
-            return cpu.set_online(self.path)
-        return cpu.set_offline(self.path)
+            cpu.set_online(self.path)
+        cpu.set_offline(self.path)

--- a/src/arbiterd/objects/instance.py
+++ b/src/arbiterd/objects/instance.py
@@ -11,7 +11,7 @@ from defusedxml import ElementTree as ET
 
 # TODO: extract this so it can be shared
 CPUAffinity = collections.namedtuple(
-    'CPUAaffinity', ['vcpu', 'vcpupin', 'emulatorpin', 'iothreadpin'])
+    'CPUAffinity', ['vcpu', 'vcpupin', 'emulatorpin', 'iothreadpin'])
 
 
 @dataclass
@@ -38,7 +38,7 @@ class Instance:
         return self._xml_str
 
     @property
-    def xml(self) -> str:
+    def xml(self) -> ET:
         if self._xml is None:
             self._xml = ET.fromstring(self.domain.XMLDesc(0))
         return self._xml


### PR DESCRIPTION
This change extends the current unit tests to add
coverage for the object classes and the arbiter
dispatcher. This change also cleans up some minor
bugs in the tested classes.
