### PR TITLE
fix apply and hashing.

### DIFF
--- a/src/arbiterd/cmd/static.py
+++ b/src/arbiterd/cmd/static.py
@@ -232,7 +232,7 @@ def run():
         help='Automatically manage the cpu online state'
     )
     arbitrate_parser.add_argument(
-        '--apply', type=int,
+        '--apply', action='store_true', default=False,
         help='apply the changes to the host.'
     )
 
@@ -249,7 +249,7 @@ def run():
         help='revoke management of the cpu online state'
     )
     revoke_parser.add_argument(
-        '--apply', type=int,
+        '--apply', action='store_true', default=False,
         help='apply the changes to the host.'
     )
     revoke_parser.set_defaults(func=revoke_command)

--- a/src/arbiterd/objects/hardware_thread.py
+++ b/src/arbiterd/objects/hardware_thread.py
@@ -36,3 +36,6 @@ class HardwareThread:
         if state:
             cpu.set_online(self.path)
         cpu.set_offline(self.path)
+
+    def __hash__(self):
+        return hash(self.ident)


### PR DESCRIPTION
as part of the unit test work the HardwareThread
object were reused when caluating the cores to offline
instead of workign with sets fo ints.

since the HardwareThread class did not define a hash fucntion they
are not valid member of a set. this is not seen in the unittests
since the autospec mock has a hash function.

this change also fixs the --apply defintion to be a bool not
an int.