### PR TITLE
extend python version testing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ['3.6', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/arbiterd_tests/base.py
+++ b/arbiterd_tests/base.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import fixtures
 import testtools
-from arbiterd.common import filesystem
 
 from arbiterd_tests import fixtures as at_fixtures
 
@@ -27,10 +26,6 @@ class ATTestCase(testtools.TestCase):
             self.useFixture(fixtures.FakeLogger())
             if self.USE_LOG_FIXTURE else None
         )
-        # clear all cached functions in setup to avoid
-        # inter test interactions.
-        filesystem.get_sys_fs_mount.cache_clear()
-        filesystem.get_etc_fs_mount.cache_clear()
 
     def replace_log_fixture(self, log_level):
         self.log_fixture = self.useFixture(

--- a/arbiterd_tests/functional/common/nova_test.py
+++ b/arbiterd_tests/functional/common/nova_test.py
@@ -18,8 +18,6 @@ class TestNovaData(base.ATTestCase):
 
     def setUp(self):
         super().setUp()
-        # clear all cached functions.
-        nova.parse_nova_conf.cache_clear()
         self.nova_file = os.path.join(
             filesystem.get_etc_fs_mount(), 'nova/nova.conf')
 

--- a/arbiterd_tests/unit/common/filesystem_test.py
+++ b/arbiterd_tests/unit/common/filesystem_test.py
@@ -14,10 +14,6 @@ class TestFSCommon(testtools.TestCase):
 
     def setUp(self):
         super().setUp()
-        # clear all cached functions in setup to avoid
-        # inter test interactions.
-        filesystem.get_sys_fs_mount.cache_clear()
-        filesystem.get_etc_fs_mount.cache_clear()
 
     def test_get_etc_fs_mount(self):
         self.assertEqual(filesystem.ETC, filesystem.get_etc_fs_mount())
@@ -27,9 +23,6 @@ class TestFSCommon(testtools.TestCase):
         open_mock = mock.mock_open(read_data=mtab_data)
         with mock.patch('builtins.open', open_mock) as m_open:
             self.assertEqual(filesystem.SYS, filesystem.get_sys_fs_mount())
-            # this function should be cached so calling it again should not
-            # result in a second read.
-            filesystem.get_sys_fs_mount()
             m_open.assert_called_once()
 
     def test_get_sys_fs_mount_raises(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,15 +12,13 @@ license = Apache-2.0
 license_files = LICENSE.txt
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
-url = https://github.com/pyscaffold/pyscaffold/
+url = https://github.com/SeanMooney/arbiterd
 # Add here related links, for example:
 project_urls =
     Documentation = https://github.com/SeanMooney/arbiterd
     Source = https://github.com/SeanMooney/arbiterd
-#    Changelog = https://pyscaffold.org/en/latest/changelog.html
     Tracker = https://github.com/SeanMooney/arbiterd/issues
-#    Conda-Forge = https://anaconda.org/conda-forge/pyscaffold
-#    Download = https://pypi.org/project/PyScaffold/#files
+    Download = https://pypi.org/project/arbiterd/#files
 #    Twitter = https://twitter.com/PyScaffold
 
 # Change if running only on Windows, Mac or Linux (comma-separated)
@@ -32,8 +30,10 @@ classifiers =
     Development Status :: 2 - Pre-Alpha
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     License :: OSI Approved :: Apache Software License
 
@@ -47,7 +47,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = >=3.8
+python_requires = >=3.6
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in
@@ -56,6 +56,8 @@ python_requires = >=3.8
 install_requires =
     libvirt-python
     defusedxml
+    importlib-metadata; python_version<"3.8"
+    dataclasses; python_version<"3.7"
 
 [options.packages.find]
 where = src

--- a/src/arbiterd/__init__.py
+++ b/src/arbiterd/__init__.py
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    # TODO: Import directly (no need for conditional)
+    # when `python_requires = >= 3.8`
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version
+else:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version
+
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/arbiterd/common/filesystem.py
+++ b/src/arbiterd/common/filesystem.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
-import functools
 import logging
 import os
 import typing as ty
@@ -14,7 +13,6 @@ ETC = '/etc'
 LOG = logging.getLogger(__name__)
 
 
-@functools.lru_cache
 def get_sys_fs_mount() -> str:
     """find the default sysfs mount point"""
     try:
@@ -34,7 +32,6 @@ def get_sys_fs_mount() -> str:
     return SYS
 
 
-@functools.lru_cache
 def get_etc_fs_mount() -> str:
     return ETC
 

--- a/src/arbiterd/common/nova.py
+++ b/src/arbiterd/common/nova.py
@@ -2,13 +2,11 @@
 # Copyright 2021 - 2021, Sean Mooney and the arbiterd contributors
 # SPDX-License-Identifier: Apache-2.0
 import configparser
-import functools
 import typing as ty
 
 from arbiterd.common import cpu
 
 
-@functools.lru_cache
 def parse_nova_conf(nova_conf: str) -> configparser.ConfigParser:
     config = configparser.ConfigParser(interpolation=None)
     config.read(nova_conf)

--- a/tox.ini
+++ b/tox.ini
@@ -87,8 +87,10 @@ commands =
 
 [gh-actions]
 python =
+    3.6: tests
     3.8: clean, build, tests, lint, docs
     3.9: tests
+    3.10: tests
 
 [flake8]
 max_line_length = 79


### PR DESCRIPTION
This change re-adds support for python 3.6 this mainly
involes removing the user of thelru cache decorator and
adding some extra deps to backport dataclass support and
package metadata parseing.

This change adds supprot for python 3.10 which already worked
but should now be tested in ci.

This change extends the tox github action to run the tests tox
env on both python 3.6 and 3.10

This change also fixes some minor url issues with the setup.cfg
